### PR TITLE
Change results page content

### DIFF
--- a/app/views/results.html
+++ b/app/views/results.html
@@ -21,7 +21,7 @@
               Search by keyword
             </label>
           </h2>
-          <input id="keyword" class="govuk-input" placeholder="e.g. accommodation">
+          <input id="keyword" class="govuk-input" placeholder="For example accommodation">
         </div>
 
         <div class="govuk-form-group">
@@ -30,7 +30,7 @@
               Search by postcode
             </label>
           </h2>
-          <input id="postcode" class="govuk-input" placeholder="e.g. W1A 1AA">
+          <input id="postcode" class="govuk-input" placeholder="For example W1A 1AA">
         </div>
 
         <input type="submit" class="govuk-button" value="Search">

--- a/app/views/results.html
+++ b/app/views/results.html
@@ -39,13 +39,13 @@
       <h2 class="govuk-heading-s">All types</h2>
       <ul>
         <li>
-          <a href="#" class="govuk-link">Accredited Programme - CRC provided</a>
+          <a href="#" class="govuk-link">Accredited programme - CRC provided</a>
         </li>
         <li>
-          <a href="#" class="govuk-link">Accredited Programme - NPS provided</a>
+          <a href="#" class="govuk-link">Accredited programme - NPS provided</a>
         </li>
         <li>
-          <a href="#" class="govuk-link">Discretionary Service</a>
+          <a href="#" class="govuk-link">Discretionary service</a>
         </li>
       </ul>
 
@@ -75,34 +75,18 @@
         <h2 class="govuk-heading-l"><a href="/details-crc" class="govuk-link">Thinking skills programme</a></h2>
 
         <p>
-          The Thinking Skills Programme (TSP) is a cognitive skills programme for men and women designed to help develop skills in:
+          TSP is a cognitive skills programme for men and women designed to help develop skills in pro-social problem solving, perspective taking, developing and managing relationships, and self-management, and encourages pro-social attitudes, behaviour and goals for the future. TSP has been designed to incorporate maximum responsivity and flexibility of delivery format.
         </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>pro-social problem solving</li>
-          <li>perspective taking</li>
-          <li>developing and managing relationships</li>
-          <li>self-management</li>
-        </ul>
-        <p>
-          It also encourages pro-social attitudes, behaviour and goals for the future.
-        </p>
-        <p>
-          TSP has been designed to incorporate maximum responsivity and flexibility of delivery format.
-        </p>
+        
         <dl class="govuk-summary-list govuk-summary-list--no-border">
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Type of interventions</th>
-            <dd class="govuk-summary-list__value">Accredited Programme - CRC provided</td>
+            <dt class="govuk-summary-list__key">Type of intervention</th>
+            <dd class="govuk-summary-list__value">Accredited programme - CRC provided</td>
           </div>
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Number of sessions</th>
             <dd class="govuk-summary-list__value">19</td>
-          </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Frequency</th>
-            <dd class="govuk-summary-list__value">Every 5 weeks minimum</td>
           </div>
 
           <div class="govuk-summary-list__row">
@@ -133,18 +117,13 @@
         </p>
         <dl class="govuk-summary-list govuk-summary-list--no-border">
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Type of interventions</th>
-            <dd class="govuk-summary-list__value">Accredited Programme - NPS provided</td>
+            <dt class="govuk-summary-list__key">Type of intervention</th>
+            <dd class="govuk-summary-list__value">Accredited programme - NPS provided</td>
           </div>
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Number of sessions</th>
             <dd class="govuk-summary-list__value">38</td>
-          </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Frequency</th>
-            <dd class="govuk-summary-list__value">Every 12 weeks minimum</td>
           </div>
 
           <div class="govuk-summary-list__row">
@@ -175,18 +154,13 @@
         </p>
         <dl class="govuk-summary-list govuk-summary-list--no-border">
           <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Type of interventions</th>
-            <dd class="govuk-summary-list__value">Discretionary Service</td>
+            <dt class="govuk-summary-list__key">Type of intervention</th>
+            <dd class="govuk-summary-list__value">Discretionary service</td>
           </div>
 
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key">Number of sessions</th>
             <dd class="govuk-summary-list__value">Max 6hrs</td>
-          </div>
-
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Frequency</th>
-            <dd class="govuk-summary-list__value">Every 12 weeks minimum</td>
           </div>
 
           <div class="govuk-summary-list__row">


### PR DESCRIPTION
Change 'Type of interventions' to 'Type of intervention'

Change 'Accredited Programme' to 'Accredited programme'

Change 'Discretionary Service' to 'Discretionary service'

Streamline long description - doesn't need to be formatted in same way as details page

Remove 'Frequency' definition terms - not needed in overview (see 'Amalgamation of everything' tab in 'Find Alpha Fields' spreadsheet)