### PR TITLE
Enable prototype to be tested with hosted APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ lib/extensions/_extensions.scss
 .start.pid
 .port.tmp
 public
-node_modules/*
+node_modules/
 .tmuxp.*
 package-lock.json

--- a/app/routes.js
+++ b/app/routes.js
@@ -8,10 +8,8 @@ const router = express.Router();
 // Add your routes here - above the module.exports line
 
 async function createAuthenticatedApiClient() {
-  const client = new HmppsOffenderAssessmentApi.ApiClient();
-
-  // For some reason the default basePath is https, which doesn't work
-  client.basePath = "http://localhost:8080";
+  const assessmentsApiBasePath = process.env.ASSESSMENTS_API_BASEPATH || 'http://localhost:8080'
+  const client = new HmppsOffenderAssessmentApi.ApiClient(assessmentsApiBasePath);
 
   // https://github.com/ministryofjustice/offender-assessments-api-kotlin/#oauth-security
   const authTokenResponse = await axios.post(

--- a/app/routes.js
+++ b/app/routes.js
@@ -10,6 +10,7 @@ const router = express.Router();
 async function createAuthenticatedApiClient() {
   const assessmentsApiBasePath = process.env.ASSESSMENTS_API_BASEPATH || 'http://localhost:8080'
   const oauthBasePath = process.env.OAUTH_BASEPATH || 'http://localhost:9090'
+  const oauthClientAuth = process.env.OAUTH_CLIENT_AUTHORIZATION || 'sentence-plan-api-client:clientsecret'
 
   const client = new HmppsOffenderAssessmentApi.ApiClient(assessmentsApiBasePath);
 
@@ -19,10 +20,7 @@ async function createAuthenticatedApiClient() {
     {},
     {
       headers: {
-        Authorization: `Basic ${Buffer.from(
-          "sentence-plan-api-client:clientsecret",
-          "utf8"
-        ).toString("base64")}`,
+        Authorization: `Basic ${Buffer.from(oauthClientAuth, "utf8").toString("base64")}`,
       },
     }
   );

--- a/app/routes.js
+++ b/app/routes.js
@@ -9,11 +9,13 @@ const router = express.Router();
 
 async function createAuthenticatedApiClient() {
   const assessmentsApiBasePath = process.env.ASSESSMENTS_API_BASEPATH || 'http://localhost:8080'
+  const oauthBasePath = process.env.OAUTH_BASEPATH || 'http://localhost:9090'
+
   const client = new HmppsOffenderAssessmentApi.ApiClient(assessmentsApiBasePath);
 
   // https://github.com/ministryofjustice/offender-assessments-api-kotlin/#oauth-security
   const authTokenResponse = await axios.post(
-    "http://localhost:9090/auth/oauth/token?grant_type=client_credentials",
+    oauthBasePath + "/auth/oauth/token?grant_type=client_credentials",
     {},
     {
       headers: {

--- a/assessments-api-client/src/ApiClient.js
+++ b/assessments-api-client/src/ApiClient.js
@@ -43,13 +43,13 @@
    * @alias module:ApiClient
    * @class
    */
-  var exports = function() {
+  var exports = function(basePath) {
     /**
      * The base URL against which to resolve every API call's (relative) path.
      * @type {String}
-     * @default https://localhost:8080
+     * @default http://localhost:8080'
      */
-    this.basePath = 'https://localhost:8080'.replace(/\/+$/, '');
+    this.basePath = basePath || 'http://localhost:8080'.replace(/\/+$/, '');
 
     /**
      * The authentication methods to be included for all API calls.


### PR DESCRIPTION
# What's new

The current version of the prototype uses APIs that are expected to be locally running. This change makes the endpoints of those APIs configurable, so the prototype can work against any deployed service.

# Notes

Environment variables added:

| Env var | Default value | Dev value |
| --- | --- | --- |
| `ASSESSMENTS_API_BASEPATH` | http://localhost:8080 | https://offender-dev.aks-dev-1.studio-hosting.service.justice.gov.uk<br/>**needs VPN** |
| `OAUTH_BASEPATH` | http://localhost:9090 | https://sign-in-dev.hmpps.service.justice.gov.uk |
| `OAUTH_CLIENT_AUTHORIZATION` | `sentence-plan-api-client:clientsecret` | `interventions-prototype:...`<br/>let's discuss how to share securely |
